### PR TITLE
Assert provided rootComponent

### DIFF
--- a/projects/ngx-testing-extra/src/lib/components/test-bed/assert-component.ts
+++ b/projects/ngx-testing-extra/src/lib/components/test-bed/assert-component.ts
@@ -2,7 +2,7 @@ import { Component, Type } from '@angular/core';
 import { Nullable } from '../../models/shared.model';
 import { isComponentAnnotation } from './component-annotation';
 
-export function assertComponent(TypeCtor: Type<any>, annotation: Nullable<Component>) {
+export function assertComponent(TypeCtor: Type<any>, annotation: Nullable<Component>): void {
   if (!isComponentAnnotation(annotation))
     throw new Error(`The provided "${TypeCtor.name}" is not a Component. Cannot create a ComponentTestBed.`);
 }

--- a/projects/ngx-testing-extra/src/lib/components/test-bed/assert-component.ts
+++ b/projects/ngx-testing-extra/src/lib/components/test-bed/assert-component.ts
@@ -1,0 +1,8 @@
+import { Component, Type } from '@angular/core';
+import { Nullable } from '../../models/shared.model';
+import { isComponentAnnotation } from './component-annotation';
+
+export function assertComponent(TypeCtor: Type<any>, annotation: Nullable<Component>) {
+  if (!isComponentAnnotation(annotation))
+    throw new Error(`The provided "${TypeCtor.name}" is not a Component. Cannot create a ComponentTestBed.`);
+}

--- a/projects/ngx-testing-extra/src/lib/components/test-bed/assert-component.ts
+++ b/projects/ngx-testing-extra/src/lib/components/test-bed/assert-component.ts
@@ -4,5 +4,5 @@ import { isComponentAnnotation } from './component-annotation';
 
 export function assertComponent(TypeCtor: Type<any>, annotation: Nullable<Component>): void {
   if (!isComponentAnnotation(annotation))
-    throw new Error(`The provided "${TypeCtor.name}" is not a Component. Cannot create a ComponentTestBed.`);
+    throw new Error(`The provided "${TypeCtor.name ?? TypeCtor}" is not a Component. Cannot create a ComponentTestBed.`);
 }

--- a/projects/ngx-testing-extra/src/lib/components/test-bed/component-annotation.ts
+++ b/projects/ngx-testing-extra/src/lib/components/test-bed/component-annotation.ts
@@ -1,4 +1,4 @@
-import { Component, Directive, NgModule, Pipe, Type } from '@angular/core';
+import { Component, Type } from '@angular/core';
 import { Nullable } from '../../models/shared.model';
 
 export function isComponentAnnotation(annotation: Nullable<Component>): boolean {
@@ -6,13 +6,11 @@ export function isComponentAnnotation(annotation: Nullable<Component>): boolean 
     || (annotation?.template !== undefined);
 }
 
-// Inspired by https://github.com/angular/angular/blob/1f8c53cd0c6c54b9d017f888567b85683ab0d348/packages/core/testing/src/resolvers.ts#L48
 export function getComponentAnnotation(ComponentCtor: Type<any>): Nullable<Component> {
   const annotations = (ComponentCtor as any)['__annotations__'];
   for (let i = annotations.length - 1; i >= 0; i --) {
     const annotation = annotations[i];
-    const isKnownType = (annotation instanceof Directive) || (annotation instanceof Component) || (annotation instanceof Pipe) || (annotation instanceof NgModule);
-    if (isKnownType) return (annotation instanceof Component) ? annotation : null;
+    if (annotation instanceof Component) return annotation;
   }
   return null;
 }

--- a/projects/ngx-testing-extra/src/lib/components/test-bed/component-annotation.ts
+++ b/projects/ngx-testing-extra/src/lib/components/test-bed/component-annotation.ts
@@ -1,0 +1,18 @@
+import { Component, Directive, NgModule, Pipe, Type } from '@angular/core';
+import { Nullable } from '../../models/shared.model';
+
+export function isComponentAnnotation(annotation: Nullable<Component>): boolean {
+  return (annotation?.templateUrl !== undefined)
+    || (annotation?.template !== undefined);
+}
+
+// Inspired by https://github.com/angular/angular/blob/1f8c53cd0c6c54b9d017f888567b85683ab0d348/packages/core/testing/src/resolvers.ts#L48
+export function getComponentAnnotation(ComponentCtor: Type<any>): Nullable<Component> {
+  const annotations = (ComponentCtor as any)['__annotations__'];
+  for (let i = annotations.length - 1; i >= 0; i --) {
+    const annotation = annotations[i];
+    const isKnownType = (annotation instanceof Directive) || (annotation instanceof Component) || (annotation instanceof Pipe) || (annotation instanceof NgModule);
+    if (isKnownType) return (annotation instanceof Component) ? annotation : null;
+  }
+  return null;
+}

--- a/projects/ngx-testing-extra/src/lib/components/test-bed/component-annotation.ts
+++ b/projects/ngx-testing-extra/src/lib/components/test-bed/component-annotation.ts
@@ -8,6 +8,8 @@ export function isComponentAnnotation(annotation: Nullable<Component>): boolean 
 
 export function getComponentAnnotation(ComponentCtor: Type<any>): Nullable<Component> {
   const annotations = (ComponentCtor as any)['__annotations__'];
+  if (!annotations) return null;
+
   for (let i = annotations.length - 1; i >= 0; i --) {
     const annotation = annotations[i];
     if (annotation instanceof Component) return annotation;

--- a/projects/ngx-testing-extra/src/lib/components/test-bed/component-test-bed-factory.ts
+++ b/projects/ngx-testing-extra/src/lib/components/test-bed/component-test-bed-factory.ts
@@ -1,14 +1,21 @@
-import { DestroyRef, Type } from '@angular/core';
+import { Component, DestroyRef, Type } from '@angular/core';
 import { ComponentFixture, TestBed, TestBedStatic, TestModuleMetadata } from '@angular/core/testing';
 import { fromInjector } from '../../injector';
-import { MaybeArray } from '../../models/shared.model';
+import { MaybeArray, Nullable } from '../../models/shared.model';
+import { assertComponent } from './assert-component';
 import { assertComponentFixture } from './assert-fixture';
+import { getComponentAnnotation } from './component-annotation';
 
 export class ComponentTestBedFactory<ComponentType> {
 
   public constructor(
     private rootComponent: Type<ComponentType>,
-  ) { }
+  ) {
+    this.annotation = getComponentAnnotation(rootComponent);
+    assertComponent(rootComponent, this.annotation);
+  }
+
+  private readonly annotation: Nullable<Component>;
 
   private testBed: TestBedStatic = TestBed;
   private fixture: ComponentFixture<ComponentType> = null!;

--- a/projects/ngx-testing-extra/src/lib/components/test-bed/component-test-bed-factory.ts
+++ b/projects/ngx-testing-extra/src/lib/components/test-bed/component-test-bed-factory.ts
@@ -53,7 +53,9 @@ export class ComponentTestBedFactory<ComponentType> {
   }
 
   public async compile(): Promise<void> {
-    this.import(this.rootComponent);
+    (this.annotation?.standalone)
+      ? this.import(this.rootComponent)
+      : this.declare(this.rootComponent);
 
     await this.testBed.compileComponents();
 

--- a/projects/ngx-testing-extra/src/tests/fixtures/helpers/annotations/get-first-annotation.ts
+++ b/projects/ngx-testing-extra/src/tests/fixtures/helpers/annotations/get-first-annotation.ts
@@ -1,0 +1,5 @@
+import { Type } from '@angular/core';
+
+export function getFirstAnnotation<T>(TypeCtor: Type<any>): T {
+  return (TypeCtor as any)['__annotations__'][0];
+}

--- a/projects/ngx-testing-extra/src/tests/integrations/components/test-bed/component-test-bed.spec.ts
+++ b/projects/ngx-testing-extra/src/tests/integrations/components/test-bed/component-test-bed.spec.ts
@@ -1,58 +1,73 @@
+import { Component } from '@angular/core';
 import { componentTestBed } from '../../../../lib/components';
 import { InnerComponent } from '../../../fixtures/components/inner.component';
 import { OuterComponent } from '../../../fixtures/components/outer.component';
 import { validateArray } from '../../../fixtures/helpers/validators/validate-array';
 
 describe('componentTestBed', () => {
-  const tb = componentTestBed(OuterComponent);
-  beforeEach(() => tb.compile());
 
-  tb.shouldCreate();
+  describe('standalone', () => {
 
-  it('should click', tb(({ component, action }) => {
-    expect(component.clicked).toBeFalse();
-    action.click('#my-outer-button');
-    expect(component.clicked).toBeTrue();
-  }));
+    const tb = componentTestBed(OuterComponent);
+    beforeEach(() => tb.compile());
 
-  it('should emit InnerComponent output', tb(({ component, action }) => {
-    expect(component.innerClicked).toBeFalse();
-    action.emitOutput(InnerComponent, 'clicked', true);
-    expect(component.innerClicked).toBeTrue();
-  }));
+    tb.shouldCreate();
 
-  it('should find InnerComponent instance', tb(({ query }) => {
-    expect(query.findComponent(InnerComponent)).toBeTruthy();
-  }));
+    it('should click', tb(({ component, action }) => {
+      expect(component.clicked).toBeFalse();
+      action.click('#my-outer-button');
+      expect(component.clicked).toBeTrue();
+    }));
 
-  it('should find InnerComponent native element', tb(({ query }) => {
-    expect(query.findElement(InnerComponent)).toBeTruthy();
-  }));
+    it('should emit InnerComponent output', tb(({ component, action }) => {
+      expect(component.innerClicked).toBeFalse();
+      action.emitOutput(InnerComponent, 'clicked', true);
+      expect(component.innerClicked).toBeTrue();
+    }));
 
-  it('should find InnerComponent debug element', tb(({ query }) => {
-    expect(query.findDebugElement(InnerComponent)).toBeTruthy();
-  }));
+    it('should find InnerComponent instance', tb(({ query }) => {
+      expect(query.findComponent(InnerComponent)).toBeTruthy();
+    }));
 
-  it('should find all InnerComponent instances', tb(({ component, fixture, query }) => {
-    component.extraInner = true;
-    fixture.detectChanges();
-    validateArray(query.findAllComponents(InnerComponent), { size: 2 });
-  }));
+    it('should find InnerComponent native element', tb(({ query }) => {
+      expect(query.findElement(InnerComponent)).toBeTruthy();
+    }));
 
-  it('should find all InnerComponent native elements', tb(({ component, fixture, query }) => {
-    component.extraInner = true;
-    fixture.detectChanges();
-    validateArray(query.findAllElements(InnerComponent), { size: 2 });
-  }));
+    it('should find InnerComponent debug element', tb(({ query }) => {
+      expect(query.findDebugElement(InnerComponent)).toBeTruthy();
+    }));
 
-  it('should find all InnerComponent debug elements', tb(({ component, fixture, query }) => {
-    component.extraInner = true;
-    fixture.detectChanges();
-    validateArray(query.findAllDebugElements(InnerComponent), { size: 2 });
-  }));
+    it('should find all InnerComponent instances', tb(({ component, fixture, query }) => {
+      component.extraInner = true;
+      fixture.detectChanges();
+      validateArray(query.findAllComponents(InnerComponent), { size: 2 });
+    }));
 
-  it('should support jasmine DoneFn', tb(({}, done: DoneFn) => {
-    expect().nothing();
-    done();
-  }));
+    it('should find all InnerComponent native elements', tb(({ component, fixture, query }) => {
+      component.extraInner = true;
+      fixture.detectChanges();
+      validateArray(query.findAllElements(InnerComponent), { size: 2 });
+    }));
+
+    it('should find all InnerComponent debug elements', tb(({ component, fixture, query }) => {
+      component.extraInner = true;
+      fixture.detectChanges();
+      validateArray(query.findAllDebugElements(InnerComponent), { size: 2 });
+    }));
+
+    it('should support jasmine DoneFn', tb(({}, done: DoneFn) => {
+      expect().nothing();
+      done();
+    }));
+  });
+
+  describe('classic', () => {
+    @Component({ template: `` })
+    class ClassicComponent {}
+
+    const tb = componentTestBed(ClassicComponent);
+    beforeEach(() => tb.compile());
+
+    tb.shouldCreate();
+  });
 });

--- a/projects/ngx-testing-extra/src/tests/units/components/test-bed/assert-component.spec.ts
+++ b/projects/ngx-testing-extra/src/tests/units/components/test-bed/assert-component.spec.ts
@@ -1,0 +1,26 @@
+import { Component, Directive } from '@angular/core';
+import { assertComponent } from '../../../../lib/components/test-bed/assert-component';
+import { getFirstAnnotation } from '../../../fixtures/helpers/annotations/get-first-annotation';
+
+describe('assertComponent', () => {
+
+  it('should pass', () => {
+    @Component({ template: `` })
+    class AppComponent {}
+
+    const annotation = getFirstAnnotation<Component>(AppComponent);
+
+    expect(() => assertComponent(AppComponent, annotation))
+      .not.toThrowError();
+  });
+
+  it('should throw error', () => {
+    @Directive({ selector: '' })
+    class AppDirective {}
+
+    const annotation = getFirstAnnotation<Directive>(AppDirective);
+
+    expect(() => assertComponent(AppDirective, annotation))
+      .toThrowError('The provided "AppDirective" is not a Component. Cannot create a ComponentTestBed.');
+  });
+});


### PR DESCRIPTION
- Assert that the provided `rootComponent` parameter of `ComponentTestBedFactory` is a Component.
- When `compile()` is used,  `import` or `declare` if the `rootComponent` is standalone or not.